### PR TITLE
Add Jenkins unit test pipeline with dual Django 1.8 + 1.11 support

### DIFF
--- a/Jenkinsfile/Jenkinsfile-unit-test.groovy
+++ b/Jenkinsfile/Jenkinsfile-unit-test.groovy
@@ -86,8 +86,8 @@ spec:
     AWS_REGION = 'ap-southeast-1'
     SOURCE_BRANCH = "${env.CHANGE_BRANCH}"
     tags = setTags(SOURCE_BRANCH, PR_NUM)
-    IMAGE_TAG = "${tags.IMAGE_TAG}"
-    CACHE_TAG = "${tags.CACHE_TAG}"
+    IMAGE_TAG_1_8 = "1-8-${tags.IMAGE_TAG}"
+    IMAGE_TAG_1_11 = "1-11-${tags.IMAGE_TAG}"
     DOCKERFILE = 'Dockerfile'
   }
   stages {
@@ -113,16 +113,11 @@ spec:
     }
     stage('Build Image & Setup Infra') {
       parallel {
-        stage('Build docker image') {
+        stage('Build docker image Django 1.8') {
           steps {
             container('nerdctl') {
               script {
                 dockerLogin(ECR_REGISTRY, AWS_REGION)
-                
-                // Determine cache source: use CACHE_TAG if exists, else fallback to 'dev-cache'
-                def cacheFromRef = getCacheFromRef(ECR_REGISTRY, FINAL_IMAGE, CACHE_TAG, AWS_REGION)
-                echo "Using cache from: ${cacheFromRef}"
-                
                 sh """
                   # Wait for buildkit to be ready
                   until buildctl --addr unix:///run/buildkit/buildkitd.sock debug workers; do
@@ -132,6 +127,8 @@ spec:
 
                   cd django-rest-framework-api-key
                   
+                  ls -lah
+
                   # Set BUILDKIT_HOST for nerdctl
                   export BUILDKIT_HOST=unix:///run/buildkit/buildkitd.sock
 
@@ -139,13 +136,45 @@ spec:
                   nerdctl build \
                     --file ${DOCKERFILE} \
                     --target django-rest-framework-api-key \
-                    --progress=plain -t ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG} \
-                    --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${ECR_REGISTRY}/${FINAL_IMAGE}:${CACHE_TAG} \
-                    --cache-from type=registry,ref=${cacheFromRef} .
-                  nerdctl push ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG}
+                    --progress=plain -t ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_8} .
+                  nerdctl push ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_8}
                   
                   echo "Cleaning up final image from local storage"
-                  nerdctl rmi ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG} || echo "Final image already removed"
+                  nerdctl rmi ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_8} || echo "Final image already removed"
+                """
+              }
+            }
+          }
+        }
+        stage('Build docker image Django 1.11') {
+          steps {
+            container('nerdctl') {
+              script {
+                dockerLogin(ECR_REGISTRY, AWS_REGION)
+                sh """
+                  # Wait for buildkit to be ready
+                  until buildctl --addr unix:///run/buildkit/buildkitd.sock debug workers; do
+                    echo "Waiting for buildkit to be ready..."
+                    sleep 5
+                  done
+
+                  cd django-rest-framework-api-key
+                  
+                  ls -lah
+
+                  # Set BUILDKIT_HOST for nerdctl
+                  export BUILDKIT_HOST=unix:///run/buildkit/buildkitd.sock
+
+                  echo Build Final Image
+                  nerdctl build \
+                    --file ${DOCKERFILE} \
+                    --target django-rest-framework-api-key \
+                    --build-arg REQUIREMENTS_FILE=requirements/django111/requirements-testing.txt \
+                    --progress=plain -t ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_11} .
+                  nerdctl push ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_11}
+                  
+                  echo "Cleaning up final image from local storage"
+                  nerdctl rmi ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_11} || echo "Final image already removed"
                 """
               }
             }
@@ -168,57 +197,115 @@ spec:
       }
     }
     stage('Run Test') {
-      agent {
-          kubernetes {
-              yaml """
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: backend
-            namespace: ${NAMESPACE}
-          spec:
-            tolerations:
-              - key: "cicd"
-                operator: "Exists"
-                effect: "NoSchedule"
-            affinity:
-              nodeAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  nodeSelectorTerms:
-                  - matchExpressions:
-                    - key: app
-                      operator: In
-                      values: ['cicd']
-            containers:
-              - name: backend
-                image: ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG}
-                imagePullPolicy: Always
-                command:
-                  - cat
-                tty: true
-                resources:
-                  limits:
-                      cpu: "256m"
-                      memory: "256Mi"
-                  requests:
-                      cpu: "256m"
-                      memory: "256Mi"
-          """
+      parallel {
+        stage('Run Test Django 1.8') {
+          agent {
+              kubernetes {
+                  yaml """
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: backend-1-8
+                namespace: ${NAMESPACE}
+              spec:
+                tolerations:
+                  - key: "cicd"
+                    operator: "Exists"
+                    effect: "NoSchedule"
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: app
+                          operator: In
+                          values: ['cicd']
+                containers:
+                  - name: backend
+                    image: ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_8}
+                    imagePullPolicy: Always
+                    command:
+                      - cat
+                    tty: true
+                    resources:
+                      limits:
+                          cpu: "256m"
+                          memory: "256Mi"
+                      requests:
+                          cpu: "256m"
+                          memory: "256Mi"
+              """
+              }
           }
-      }
-      steps {
-          container('backend') {
-              script {
-                  try {
-                      sh """
-                        cd /code && python runtests.py
-                      """
-                  } catch (Exception e) {
-                      echo "Tests failed"
-                      throw e
+          steps {
+              container('backend') {
+                  script {
+                      try {
+                          sh """
+                            cd /code && python runtests.py
+                          """
+                      } catch (Exception e) {
+                          echo "Tests failed"
+                          throw e
+                      }
                   }
               }
           }
+        }
+        stage('Run Test Django 1.11') {
+          agent {
+              kubernetes {
+                  yaml """
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: backend-1-11
+                namespace: ${NAMESPACE}
+              spec:
+                tolerations:
+                  - key: "cicd"
+                    operator: "Exists"
+                    effect: "NoSchedule"
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: app
+                          operator: In
+                          values: ['cicd']
+                containers:
+                  - name: backend
+                    image: ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_11}
+                    imagePullPolicy: Always
+                    command:
+                      - cat
+                    tty: true
+                    resources:
+                      limits:
+                          cpu: "256m"
+                          memory: "256Mi"
+                      requests:
+                          cpu: "256m"
+                          memory: "256Mi"
+              """
+              }
+          }
+          steps {
+              container('backend') {
+                  script {
+                      try {
+                          sh """
+                            cd /code && python runtests.py
+                          """
+                      } catch (Exception e) {
+                          echo "Tests failed"
+                          throw e
+                      }
+                  }
+              }
+          }
+        }
       }
     }
   }
@@ -243,43 +330,13 @@ def dockerLogin(ecrRegistry, awsRegion) {
 
 def setTags(SOURCE_BRANCH, PR_NUM) {
     def IMAGE_TAG
-    def CACHE_TAG
 
     if (SOURCE_BRANCH == 'dev' || SOURCE_BRANCH == 'master') {
         IMAGE_TAG = "${SOURCE_BRANCH}-${PR_NUM}"
-        CACHE_TAG = "${SOURCE_BRANCH}-cache"
     } else {
         IMAGE_TAG = "pr-${PR_NUM}"
-        CACHE_TAG = "pr-${PR_NUM}-cache"
     }
 
-    return [IMAGE_TAG: IMAGE_TAG, CACHE_TAG: CACHE_TAG]
+    return [IMAGE_TAG: IMAGE_TAG]
 }
 
-def getCacheFromRef(ecrRegistry, repoName, cacheTag, awsRegion) {
-    // Check if CACHE_TAG exists in ECR
-    def cacheTagExists = sh(
-        script: "aws ecr describe-images --repository-name ${repoName} --image-ids imageTag=${cacheTag} --region ${awsRegion} > /dev/null 2>&1",
-        returnStatus: true
-    ) == 0
-
-    if (cacheTagExists) {
-        echo "Cache with tag ${cacheTag} found in ECR, using it as cache source"
-        return "${ecrRegistry}/${repoName}:${cacheTag}"
-    }
-
-    // Fallback to dev-cache tag
-    def devCacheExists = sh(
-        script: "aws ecr describe-images --repository-name ${repoName} --image-ids imageTag=dev-cache --region ${awsRegion} > /dev/null 2>&1",
-        returnStatus: true
-    ) == 0
-
-    if (devCacheExists) {
-        echo "Falling back to 'dev-cache' tag as cache source"
-        return "${ecrRegistry}/${repoName}:dev-cache"
-    }
-
-    // No cache available, return the original cache tag (will just miss cache)
-    echo "No existing cache found, will create new cache with tag: ${cacheTag}"
-    return "${ecrRegistry}/${repoName}:${cacheTag}"
-}

--- a/Jenkinsfile/Jenkinsfile-unit-test.groovy
+++ b/Jenkinsfile/Jenkinsfile-unit-test.groovy
@@ -88,6 +88,8 @@ spec:
     tags = setTags(SOURCE_BRANCH, PR_NUM)
     IMAGE_TAG_1_8 = "1-8-${tags.IMAGE_TAG}"
     IMAGE_TAG_1_11 = "1-11-${tags.IMAGE_TAG}"
+    CACHE_TAG_1_8 = 'cache-django-1-8'
+    CACHE_TAG_1_11 = 'cache-django-1-11'
     DOCKERFILE = 'Dockerfile'
   }
   stages {
@@ -136,6 +138,8 @@ spec:
                   nerdctl build \
                     --file ${DOCKERFILE} \
                     --target django-rest-framework-api-key \
+                    --cache-from type=registry,ref=${ECR_REGISTRY}/${FINAL_IMAGE}:${CACHE_TAG_1_8} \
+                    --cache-to type=registry,ref=${ECR_REGISTRY}/${FINAL_IMAGE}:${CACHE_TAG_1_8},mode=max \
                     --progress=plain -t ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_8} .
                   nerdctl push ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_8}
                   
@@ -170,6 +174,8 @@ spec:
                     --file ${DOCKERFILE} \
                     --target django-rest-framework-api-key \
                     --build-arg REQUIREMENTS_FILE=requirements/django111/requirements-testing.txt \
+                    --cache-from type=registry,ref=${ECR_REGISTRY}/${FINAL_IMAGE}:${CACHE_TAG_1_11} \
+                    --cache-to type=registry,ref=${ECR_REGISTRY}/${FINAL_IMAGE}:${CACHE_TAG_1_11},mode=max \
                     --progress=plain -t ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_11} .
                   nerdctl push ${ECR_REGISTRY}/${FINAL_IMAGE}:${IMAGE_TAG_1_11}
                   

--- a/Jenkinsfile/Jenkinsfile-unit-test.groovy
+++ b/Jenkinsfile/Jenkinsfile-unit-test.groovy
@@ -129,8 +129,6 @@ spec:
 
                   cd django-rest-framework-api-key
                   
-                  ls -lah
-
                   # Set BUILDKIT_HOST for nerdctl
                   export BUILDKIT_HOST=unix:///run/buildkit/buildkitd.sock
 
@@ -164,8 +162,6 @@ spec:
 
                   cd django-rest-framework-api-key
                   
-                  ls -lah
-
                   # Set BUILDKIT_HOST for nerdctl
                   export BUILDKIT_HOST=unix:///run/buildkit/buildkitd.sock
 


### PR DESCRIPTION
## Summary
Adds a Jenkins declarative pipeline for running unit tests on pull requests, with parallel testing against both Django 1.8 and Django 1.11.
## Changes
- **`Jenkinsfile/Jenkinsfile-unit-test.groovy`**: Jenkins pipeline that:
  - Builds two Docker images in parallel (Django 1.8 default + Django 1.11 via `REQUIREMENTS_FILE` build-arg)
  - Runs `python runtests.py` in parallel against both images
  - Uses Kubernetes pods with nerdctl v2.1.6 + BuildKit v0.27.1
  - Cleans up the test namespace on completion
## Testing
- Django 1.8: uses default `requirements/django18/requirements-testing.txt`\n- Django 1.11: uses `requirements/django111/requirements-testing.txt` via `--build-arg`